### PR TITLE
Xcode 8.0 and Swift 2.3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ If you're attending either, be sure to say hello!
 This version of BitsySwift has been tested with:
 
  * OS X 10.11 (El Capitan)
- * [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) 7.3.1
- * Swift 2.2
+ * [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) 8.0
+ * Swift 2.3
 
-Xcode 8, macOS Sierra, and Swift 3 support is forthcoming. Linux
-support is currently limited by
+Swift 3 support is forthcoming. The project should also run fine in macOS Sierra.
+Linux support is currently limited by
 [Swift Foundation](https://github.com/apple/swift-corelibs-foundation) but
 should come eventually.
 

--- a/bitsy-swift.xcodeproj/project.pbxproj
+++ b/bitsy-swift.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 				TargetAttributes = {
 					B44ABF4A1D2709010012F25B = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -286,6 +287,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -293,6 +295,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/bitsy-swift/SwiftGenerator.swift
+++ b/bitsy-swift/SwiftGenerator.swift
@@ -32,7 +32,7 @@ struct SwiftGenerator: CodeGenerator {
         emitLine("var variables = Variables()")
         emitLine("var stack: [Int] = []")
         emitLine("func readIn() -> Int {")
-        emitLine("if let input = readLine(), intInput = Int(input) { return intInput")
+        emitLine("if let input = readLine(), let intInput = Int(input) { return intInput")
         emitLine("} else { return 0 } }")
         emitLine()
     }


### PR DESCRIPTION
Update the project to work with Xcode 8.0 and Swift 2.3. The *generated* Swift code is now Swift 3.0 compatible, to work with the command line `swiftc` defaults.